### PR TITLE
fix: allow Bash tool in claude-code-action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash,Read,Write,Glob,Grep"
           prompt: |
             Review this PR focusing on:
             1. Code quality and best practices


### PR DESCRIPTION
## Problem

The `claude-code-action` workflow was failing with `permission_denials` when trying to run Bash commands like `gh pr list` and `git log`. Without explicit tool permissions, the action blocks all shell execution.

## Fix

Added `allowed_tools: "Bash,Read,Write,Glob,Grep"` to the `claude.yml` workflow config. This grants the action the tools it needs to inspect repo state, read diffs, and post meaningful review comments.

## Change

```yaml
allowed_tools: "Bash,Read,Write,Glob,Grep"
```

One line added to `.github/workflows/claude.yml`.