### PR TITLE
fix: claude-code-action permissions for CI

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,5 +33,5 @@ jobs:
             2. Potential bugs or logic errors
             3. Security vulnerabilities
             4. Performance issues
-          claude_args: "--max-turns 5"
+          claude_args: "--dangerously-skip-permissions --max-turns 5"
           show_full_output: true


### PR DESCRIPTION
Add --dangerously-skip-permissions flag to bypass Bash permission prompts in GitHub Actions. Fixes failing Claude code reviews.