### PR TITLE
fix: rename default branch from master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Renames the default Git branch from "master" to "main" following modern conventions.

## Changes

- Created main branch from master
- Set main as default branch on GitHub
- Updated workflow references from master to main (if applicable)

## Testing

- Verified main branch exists and matches master
- Confirmed default branch setting on GitHub

Fixes kc2-io/BotOrNot#27