### PR TITLE
Add clickable eliminator name in metadata view

### DIFF
--- a/BotOrNot.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/BotOrNot.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -187,6 +187,9 @@ public class MainWindowViewModel : ReactiveObject
                 : "Placement: Unknown";
 
             // Extract eliminator name for clickable link (only when we know they didn't win)
+            // Note: Only shows eliminator when owner placement is known (not null).
+            // Original behavior showed eliminator even when placement was unknown; this change
+            // is intentional to avoid showing misleading information when owner wasn't found.
             EliminatorName = ownerPlacement is not null and not "1" && data.OwnerEliminatedBy != null
                 ? data.OwnerEliminatedBy
                 : null;

--- a/BotOrNot.Avalonia/Views/MainWindow.axaml
+++ b/BotOrNot.Avalonia/Views/MainWindow.axaml
@@ -59,7 +59,8 @@
                 BorderThickness="1"
                 Padding="8"
                 Margin="8,0,8,8"
-                Height="80">
+                Height="100">
+            <!-- TODO: Extract hardcoded colors to style resources for dark mode support -->
             <ScrollViewer VerticalScrollBarVisibility="Auto">
                 <StackPanel Orientation="Vertical" Spacing="2">
                     <TextBlock Text="{Binding MetadataText}" TextWrapping="Wrap" />
@@ -82,7 +83,6 @@
                                     <Setter Property="Foreground" Value="#005A9E" />
                                 </Style>
                             </Button.Styles>
-                            <!-- TODO: Extract hardcoded colors to style resources for dark mode support -->
                         </Button>
                     </StackPanel>
                 </StackPanel>


### PR DESCRIPTION
Closes #16

### Changes
- Added EliminatorName property to ViewModel to store eliminator separately
- Added FilterByPlayerCommand that sets filter text when eliminator name is clicked
- Replaced read-only TextBox with styled Border and TextBlock for metadata
- Added clickable button for eliminator name with hover styling
- Button click populates the data table filter with eliminator's name

### How it works
When viewing a replay where the owner was eliminated, the eliminator's name now appears as a clickable link in the metadata section. Clicking on it populates the filter text box with that player's name, instantly filtering both data tables to show only that player's information.

This makes it easy to quickly analyze a specific player's data (e.g., to see if they're a bot, their stats, platform, etc.).