### PR TITLE
Fix NU1903: pin Tmds.DBus.Protocol to 0.21.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- Pin transitive Tmds.DBus.Protocol to fix NU1903 (GHSA-xrw6-gwf8-vvr9, high severity, affects < 0.21.0) -->
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- Adds `Directory.Build.props` at the solution root to pin `Tmds.DBus.Protocol` to 0.21.3
- Fixes NU1903 high-severity vulnerability warning (GHSA-xrw6-gwf8-vvr9) appearing in `BotOrNot.Avalonia`, `BotOrNot.Tests`, and `BotOrNot.UITests`
- The package is a transitive dependency of Avalonia; `Directory.Build.props` overrides it across all projects in one place

## Test plan

- [ ] CI build passes with no NU1903 warnings
- [ ] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)