### PR TITLE
feat: infer squad size from TeamIndex grouping

### DIFF
--- a/BotOrNot.Avalonia/Views/MainWindow.axaml
+++ b/BotOrNot.Avalonia/Views/MainWindow.axaml
@@ -200,6 +200,7 @@
                 <DataGridTextColumn Header="Platform" Binding="{Binding Platform, Converter={StaticResource PlatformNameConverter}}" Width="130" />
                 <DataGridTextColumn Header="Kills" Binding="{Binding Kills, Converter={StaticResource UnknownToDashConverter}}" Width="91" />
                 <DataGridTextColumn Header="Squad" Binding="{Binding TeamIndex, Converter={StaticResource SquadDisplayConverter}}" Width="100" />
+                <DataGridTextColumn Header="Squad Size" Binding="{Binding SquadSize}" Width="90" />
                 <DataGridTextColumn Header="Place" Binding="{Binding Placement, Converter={StaticResource UnknownToDashConverter}}" Width="90" />
                 <DataGridTextColumn Header="Death Cause" Binding="{Binding DeathCause}" Width="156" />
                 <DataGridTextColumn Header="Elim Time" Binding="{Binding ElimTime}" Width="90" />
@@ -274,6 +275,7 @@
                 <DataGridTextColumn Header="Platform" Binding="{Binding Platform, Converter={StaticResource PlatformNameConverter}}" Width="130" />
                 <DataGridTextColumn Header="Kills" Binding="{Binding Kills, Converter={StaticResource UnknownToDashConverter}}" Width="91" />
                 <DataGridTextColumn Header="Squad" Binding="{Binding TeamIndex, Converter={StaticResource SquadDisplayConverter}}" Width="100" />
+                <DataGridTextColumn Header="Squad Size" Binding="{Binding SquadSize}" Width="90" />
                 <DataGridTextColumn Header="Place" Binding="{Binding Placement, Converter={StaticResource UnknownToDashConverter}}" Width="90" />
                 <DataGridTextColumn Header="Death Cause" Binding="{Binding DeathCause}" Width="156" />
                 <DataGridTextColumn Header="Elim Time" Binding="{Binding ElimTime}" Width="90" />

--- a/BotOrNot.Core/Models/PlayerRow.cs
+++ b/BotOrNot.Core/Models/PlayerRow.cs
@@ -15,6 +15,7 @@ public sealed class PlayerRow
     public string? ElimTime { get; set; }
     public string? Pickaxe { get; set; }
     public string? Glider { get; set; }
+    public int SquadSize { get; set; }
 
     public bool IsBot => !string.IsNullOrEmpty(Bot) && Bot.Equals("true", StringComparison.OrdinalIgnoreCase);
     public bool IsWinner => Placement == "1";

--- a/BotOrNot.Core/Services/ReplayService.cs
+++ b/BotOrNot.Core/Services/ReplayService.cs
@@ -322,7 +322,8 @@ public sealed class ReplayService : IReplayService
                         Placement = victim.Placement,
                         ElimTime = eventTimeStr,
                         Pickaxe = victim.Pickaxe,
-                        Glider = victim.Glider
+                        Glider = victim.Glider,
+                        SquadSize = victim.SquadSize
                     });
                 }
 

--- a/BotOrNot.Core/Services/ReplayService.cs
+++ b/BotOrNot.Core/Services/ReplayService.cs
@@ -150,6 +150,21 @@ public sealed class ReplayService : IReplayService
                 ownerKills = kills;
         }
 
+        // === Compute squad sizes from TeamIndex grouping ===
+        var squadSizeByTeamIndex = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var row in playersById.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(row.TeamIndex) && row.TeamIndex != "unknown")
+            {
+                squadSizeByTeamIndex[row.TeamIndex] = squadSizeByTeamIndex.GetValueOrDefault(row.TeamIndex) + 1;
+            }
+        }
+        foreach (var row in playersById.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(row.TeamIndex) && squadSizeByTeamIndex.TryGetValue(row.TeamIndex, out var sz))
+                row.SquadSize = sz;
+        }
+
         // === PASS 2: Team data (unchanged — small collection) ===
         var teamKillsByIndex = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var teamPlacementByIndex = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
Closes #7

Implements squad size inference by counting players sharing the same `TeamIndex` in the replay data — no new data source needed.

## Changes
- `PlayerRow`: adds `int SquadSize` property
- `ReplayService`: builds a `squadSizeByTeamIndex` dictionary after Pass 1, then assigns `SquadSize` to each player
- `MainWindow.axaml`: adds "Squad Size" column after "Squad" in both Owner Eliminations and All Players grids

## Test plan
- [ ] `dotnet test` passes
- [ ] Load a solo replay → Squad Size = 1 for all players
- [ ] Load a duos replay → Squad Size = 2 for players on the same team
- [ ] Load a squads replay → Squad Size = 4 for players on the same team