### PR TITLE
feat: add .editorconfig and dotnet format CI step

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,58 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_size = 4
+
+# Namespace and using
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# var preferences
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Expression-body
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_constructors = false:silent
+
+# Modifier ordering
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
+
+# Braces
+csharp_prefer_braces = true:suggestion
+
+# New-line
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# Spacing
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+
+# Indentation
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+
+[*.{xml,axaml,csproj,props,targets}]
+indent_size = 2
+end_of_line = crlf
+
+[*.{json,yml,yaml}]
+indent_size = 2
+end_of_line = lf
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
+      - name: Format check
+        run: dotnet format --verify-no-changes --verbosity diagnostic
+        continue-on-error: true  # remove after running `dotnet format` baseline commit
+
       - name: Build
         run: dotnet build --configuration Release --no-restore
 


### PR DESCRIPTION
Closes #15

Adds `.editorconfig` with C# formatting conventions and a `dotnet format --verify-no-changes` step in the build pipeline.

## What's added

- **`.editorconfig`** — defines indent style, brace placement, namespace sorting, var preferences, and spacing rules for `.cs`, `.axaml/.csproj/.props`, `.json/.yml`, and `.md` files
- **Format check step in `build.yml`** — runs `dotnet format --verify-no-changes` after `dotnet restore`

## One follow-up needed

The format check step is currently set to `continue-on-error: true` because the existing codebase may have minor formatting differences from the new rules. To make it blocking:

1. Run `dotnet format` locally on the solution to apply the baseline
2. Commit the formatted files
3. Remove `continue-on-error: true` from `build.yml`

## Test plan
- [ ] Build passes (format step shows but doesn't block due to `continue-on-error`)
- [ ] Run `dotnet format` locally — observe what (if anything) it changes
- [ ] Follow-up commit to baseline existing code, then remove `continue-on-error`