### PR TITLE
feat: game mode filter in library view (closes #4)

### DIFF
--- a/BotOrNot.Avalonia/ViewModels/LibraryViewModel.cs
+++ b/BotOrNot.Avalonia/ViewModels/LibraryViewModel.cs
@@ -16,8 +16,11 @@ public sealed class FrequentOpponent
 
 public class LibraryViewModel : ReactiveObject
 {
+    private const string AllModes = "(All modes)";
+
     private readonly IReplayCacheService _cacheService;
     private readonly Action<ReplaySummary> _onOpenReplay;
+    private readonly List<ReplaySummary> _allReplays = new();
 
     private string? _directoryPath;
     private bool _isScanning;
@@ -29,6 +32,8 @@ public class LibraryViewModel : ReactiveObject
     private double _avgKills;
     private double _avgBotPercent;
     private bool _hasReplays;
+    private string _gameModeFilter = AllModes;
+    private IReadOnlyList<string> _availableGameModes = Array.Empty<string>();
 
     public LibraryViewModel(Action<ReplaySummary> onOpenReplay, IReplayCacheService? cacheService = null)
     {
@@ -62,6 +67,22 @@ public class LibraryViewModel : ReactiveObject
 
     public ObservableCollection<ReplaySummary> Replays { get; }
     public IReadOnlyList<FrequentOpponent> FrequentOpponents { get; private set; }
+
+    public string GameModeFilter
+    {
+        get => _gameModeFilter;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _gameModeFilter, value);
+            ApplyFilter();
+        }
+    }
+
+    public IReadOnlyList<string> AvailableGameModes
+    {
+        get => _availableGameModes;
+        private set => this.RaiseAndSetIfChanged(ref _availableGameModes, value);
+    }
 
     public string? DirectoryPath
     {
@@ -143,10 +164,21 @@ public class LibraryViewModel : ReactiveObject
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                Replays.Clear();
-                foreach (var s in ordered)
-                    Replays.Add(s);
-                UpdateStats();
+                _allReplays.Clear();
+                _allReplays.AddRange(ordered);
+
+                var modes = _allReplays
+                    .Select(r => r.GameMode)
+                    .Where(m => !string.IsNullOrEmpty(m))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(m => m)
+                    .ToList();
+                AvailableGameModes = new[] { AllModes }.Concat(modes).ToArray();
+
+                if (_gameModeFilter != AllModes && !modes.Contains(_gameModeFilter, StringComparer.OrdinalIgnoreCase))
+                    _gameModeFilter = AllModes;
+
+                ApplyFilter();
             });
         }
         catch (OperationCanceledException) { }
@@ -158,6 +190,19 @@ public class LibraryViewModel : ReactiveObject
         {
             IsScanning = false;
         }
+    }
+
+    private void ApplyFilter()
+    {
+        var filtered = _gameModeFilter == AllModes
+            ? _allReplays
+            : _allReplays.Where(r => string.Equals(r.GameMode, _gameModeFilter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        Replays.Clear();
+        foreach (var s in filtered)
+            Replays.Add(s);
+
+        UpdateStats();
     }
 
     private void UpdateStats()

--- a/BotOrNot.Avalonia/Views/LibraryView.axaml
+++ b/BotOrNot.Avalonia/Views/LibraryView.axaml
@@ -26,6 +26,12 @@
             <Button Content="Scan"
                     Command="{Binding ScanCommand}"
                     IsVisible="{Binding DirectoryPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            <ComboBox ItemsSource="{Binding AvailableGameModes}"
+                      SelectedItem="{Binding GameModeFilter}"
+                      MinWidth="140"
+                      VerticalAlignment="Center"
+                      ToolTip.Tip="Filter by game mode"
+                      IsVisible="{Binding HasReplays}" />
             <ProgressBar Value="{Binding ScanProgress}"
                          Minimum="0" Maximum="100"
                          IsVisible="{Binding IsScanning}"


### PR DESCRIPTION
Closes #4

Adds a game mode filter ComboBox to the LibraryView toolbar. Modes are populated from the loaded replays and de-duplicated. Selecting a mode filters both the replay list and the aggregate stats strip. Selecting the "(All modes)" entry resets to show everything.

**Depends on #49** (library view) — please merge that first; this branch is based off `feature/issue-3-library-view`.

## Test plan
- [ ] dotnet test passes
- [ ] Scan a folder with mixed-mode replays; ComboBox shows distinct modes
- [ ] Selecting a mode filters the DataGrid and updates stats (total, win rate, avg kills, avg bot%)
- [ ] Selecting "(All modes)" restores the full list
- [ ] Filter persists after re-scan; resets to All if the previously-selected mode disappears
